### PR TITLE
fix(hooks): replace GNU-only `grep -P` with portable equivalents (macOS merge gate blocks all merges)

### DIFF
--- a/.github/workflows/hook-portability.yml
+++ b/.github/workflows/hook-portability.yml
@@ -1,0 +1,24 @@
+name: hook portability
+
+# The hooks in hooks/ run on contributors' machines under whatever grep/sed/awk
+# the host provides. macOS ships BSD grep, which rejects GNU-only flags such as
+# -P. Running the suite on both runners keeps that difference visible.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    name: hooks (${{ matrix.os }})
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run hook portability tests
+        run: bash tests/test-hook-portability.sh

--- a/hooks/capture-catastrophiser.sh
+++ b/hooks/capture-catastrophiser.sh
@@ -44,15 +44,19 @@ VERIFICATION_OUTPUT=""
 if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
     # Extract the last JSON block that looks like catastrophiser output
     # Look for status field (PASS/FAIL) and evidence field
+    # -oE (POSIX ERE) rather than -oP: PCRE is a GNU extension unavailable in
+    # BSD grep (macOS default). \s is spelled [[:space:]] for portability.
     VERIFICATION_OUTPUT=$(tail -100 "$TRANSCRIPT_PATH" | \
-        grep -oP '\{[^{}]*"status"\s*:\s*"(PASS|FAIL)"[^{}]*\}' | \
+        grep -oE '\{[^{}]*"status"[[:space:]]*:[[:space:]]*"(PASS|FAIL)"[^{}]*\}' | \
         tail -1 || echo "")
 
-    # If simple extraction failed, try multiline JSON extraction
+    # If simple extraction failed, try multiline JSON extraction.
+    # Flattening newlines to spaces gives the same reach as PCRE's (?s)
+    # DOTALL flag without needing `grep -Pzo`.
     if [ -z "$VERIFICATION_OUTPUT" ]; then
-        VERIFICATION_OUTPUT=$(tail -200 "$TRANSCRIPT_PATH" | \
-            grep -Pzo '(?s)\{[^{}]*"verified_at"[^{}]*"status"[^{}]*\}' | \
-            tr '\0' '\n' | tail -1 || echo "")
+        VERIFICATION_OUTPUT=$(tail -200 "$TRANSCRIPT_PATH" | tr '\n' ' ' | \
+            grep -oE '\{[^{}]*"verified_at"[^{}]*"status"[^{}]*\}' | \
+            tail -1 || echo "")
     fi
 fi
 

--- a/hooks/capture-cynic.sh
+++ b/hooks/capture-cynic.sh
@@ -44,15 +44,19 @@ SIMPLIFICATION_OUTPUT=""
 if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
     # Extract the last JSON block that looks like cynic output
     # Look for simplifications_made and tests_still_pass fields
+    # -oE (POSIX ERE) rather than -oP: PCRE is a GNU extension unavailable in
+    # BSD grep (macOS default), and this pattern needs no PCRE features.
     SIMPLIFICATION_OUTPUT=$(tail -100 "$TRANSCRIPT_PATH" | \
-        grep -oP '\{[^{}]*"tests_still_pass"[^{}]*\}' | \
+        grep -oE '\{[^{}]*"tests_still_pass"[^{}]*\}' | \
         tail -1 || echo "")
 
-    # If simple extraction failed, try multiline JSON extraction
+    # If simple extraction failed, try multiline JSON extraction.
+    # Flattening newlines to spaces gives the same reach as PCRE's (?s)
+    # DOTALL flag without needing `grep -Pzo`.
     if [ -z "$SIMPLIFICATION_OUTPUT" ]; then
-        SIMPLIFICATION_OUTPUT=$(tail -200 "$TRANSCRIPT_PATH" | \
-            grep -Pzo '(?s)\{[^{}]*"simplifications_made"[^{}]*"tests_still_pass"[^{}]*\}' | \
-            tr '\0' '\n' | tail -1 || echo "")
+        SIMPLIFICATION_OUTPUT=$(tail -200 "$TRANSCRIPT_PATH" | tr '\n' ' ' | \
+            grep -oE '\{[^{}]*"simplifications_made"[^{}]*"tests_still_pass"[^{}]*\}' | \
+            tail -1 || echo "")
     fi
 fi
 

--- a/hooks/capture-perfectionist.sh
+++ b/hooks/capture-perfectionist.sh
@@ -44,15 +44,19 @@ AGENT_OUTPUT=""
 if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
     # Extract the last JSON block that looks like perfectionist output
     # Look for files_updated field
+    # -oE (POSIX ERE) rather than -oP: PCRE is a GNU extension unavailable in
+    # BSD grep (macOS default), and this pattern needs no PCRE features.
     AGENT_OUTPUT=$(tail -100 "$TRANSCRIPT_PATH" | \
-        grep -oP '\{[^{}]*"files_updated"[^{}]*\}' | \
+        grep -oE '\{[^{}]*"files_updated"[^{}]*\}' | \
         tail -1 || echo "")
 
-    # If simple extraction failed, try multiline JSON extraction
+    # If simple extraction failed, try multiline JSON extraction.
+    # Flattening newlines to spaces gives the same reach as PCRE's (?s)
+    # DOTALL flag without needing `grep -Pzo`.
     if [ -z "$AGENT_OUTPUT" ]; then
-        AGENT_OUTPUT=$(tail -200 "$TRANSCRIPT_PATH" | \
-            grep -Pzo '(?s)\{[^{}]*"sections_approved"[^{}]*\}' | \
-            tr '\0' '\n' | tail -1 || echo "")
+        AGENT_OUTPUT=$(tail -200 "$TRANSCRIPT_PATH" | tr '\n' ' ' | \
+            grep -oE '\{[^{}]*"sections_approved"[^{}]*\}' | \
+            tail -1 || echo "")
     fi
 fi
 

--- a/hooks/create-task-branch.sh
+++ b/hooks/create-task-branch.sh
@@ -30,8 +30,11 @@ fi
 # Extract task info from prompt (passed by execute command)
 # Format expected: TASK_ID: <id> TASK_SLUG: <slug>
 PROMPT=$(echo "$INPUT" | jq -r '.prompt // ""')
-TASK_ID=$(echo "$PROMPT" | grep -oP 'TASK_ID:\s*\K[^\s]+' || echo "")
-TASK_SLUG=$(echo "$PROMPT" | grep -oP 'TASK_SLUG:\s*\K[^\s]+' || echo "unknown")
+# `sed -nE` is used instead of `grep -oP ... \K` because -P (PCRE) is a GNU
+# extension that BSD grep (macOS default) does not support.
+TASK_ID=$(printf '%s\n' "$PROMPT" | sed -nE 's/.*TASK_ID:[[:space:]]*([^[:space:]]+).*/\1/p' | head -1)
+TASK_SLUG=$(printf '%s\n' "$PROMPT" | sed -nE 's/.*TASK_SLUG:[[:space:]]*([^[:space:]]+).*/\1/p' | head -1)
+TASK_SLUG="${TASK_SLUG:-unknown}"
 
 # If no task ID, this isn't a task execution - allow spawn
 if [ -z "$TASK_ID" ]; then

--- a/hooks/merge-gate.sh
+++ b/hooks/merge-gate.sh
@@ -26,7 +26,16 @@ fi
 
 # Extract branch name being merged (if present)
 # Patterns: "git merge branch-name", "git merge origin/branch"
-MERGE_BRANCH=$(echo "$COMMAND" | grep -oP 'git\s+merge\s+\K[^\s;|&]+' || echo "")
+# POSIX awk is used instead of `grep -oP ... \K` because -P (PCRE) is a GNU
+# extension that BSD grep (macOS default) does not support.
+MERGE_BRANCH=$(printf '%s\n' "$COMMAND" | awk '{
+    while (match($0, /git[ \t]+merge[ \t]+[^ \t;|&]+/)) {
+        m = substr($0, RSTART, RLENGTH)
+        sub(/^git[ \t]+merge[ \t]+/, "", m)
+        print m
+        $0 = substr($0, RSTART + RLENGTH)
+    }
+}')
 
 if [ -z "$MERGE_BRANCH" ]; then
     echo "Cannot determine branch being merged. Merge blocked for safety." >&2
@@ -35,7 +44,16 @@ fi
 
 # Extract task ID from branch name
 # Format: execute/task-{id}-{slug}-{uuid}
-TASK_ID=$(echo "$MERGE_BRANCH" | grep -oP 'task-\K[^-]+' || echo "")
+# Shell parameter expansion avoids the non-portable `grep -oP ... \K`.
+case "$MERGE_BRANCH" in
+    *task-*)
+        TASK_ID="${MERGE_BRANCH#*task-}"   # strip through the first "task-"
+        TASK_ID="${TASK_ID%%-*}"           # keep up to the next "-"
+        ;;
+    *)
+        TASK_ID=""
+        ;;
+esac
 
 if [ -z "$TASK_ID" ]; then
     # Not a task branch - might be a regular merge, allow it

--- a/hooks/task-completion-capture.sh
+++ b/hooks/task-completion-capture.sh
@@ -51,8 +51,10 @@ fi
 TASK_OUTPUT=""
 if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
     # Extract the last assistant message that looks like JSON output
+    # -oE (POSIX ERE) rather than -oP: PCRE is a GNU extension unavailable in
+    # BSD grep (macOS default), and this pattern needs no PCRE features.
     TASK_OUTPUT=$(tail -50 "$TRANSCRIPT_PATH" | \
-        grep -oP '\{[^{}]*"status"[^{}]*\}' | \
+        grep -oE '\{[^{}]*"status"[^{}]*\}' | \
         tail -1 || echo "")
 fi
 

--- a/tests/test-hook-portability.sh
+++ b/tests/test-hook-portability.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# Portability regression tests for the hooks in hooks/.
+#
+# These hooks run under /bin/bash with whatever `grep`/`sed`/`awk` the host
+# provides. GNU-only extensions (notably `grep -P`) are therefore forbidden:
+# BSD grep, the macOS default, rejects them and the hook fails.
+#
+# Run locally:  bash tests/test-hook-portability.sh
+# CI runs this on both ubuntu-latest (GNU) and macos-latest (BSD).
+
+set -uo pipefail
+
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+HOOKS="$REPO_ROOT/hooks"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+PASS=0
+FAIL=0
+
+echo "grep:  $(grep --version 2>/dev/null | head -1 || echo 'BSD grep')"
+echo "sed:   $(sed --version 2>/dev/null | head -1 || echo 'BSD sed')"
+echo "awk:   $(awk --version 2>/dev/null | head -1 || echo 'BSD awk')"
+echo
+
+ok()  { PASS=$((PASS + 1)); printf '  PASS  %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL  %s\n          %s\n' "$1" "$2"; }
+
+# ---------------------------------------------------------------------------
+# 1. Static scan: no GNU-only grep flags in any hook (ignoring comments).
+# ---------------------------------------------------------------------------
+echo "=== no GNU-only grep flags ==="
+OFFENDERS=$(grep -rn -e 'grep -oP' -e 'grep -Pzo' -e 'grep -P ' "$HOOKS/" 2>/dev/null \
+    | grep -vE '^[^:]+:[0-9]+:[[:space:]]*#')
+if [ -z "$OFFENDERS" ]; then
+    ok "no 'grep -P' usages in hooks/"
+else
+    bad "GNU-only 'grep -P' found" "$OFFENDERS"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Every hook parses under bash -n.
+# ---------------------------------------------------------------------------
+echo
+echo "=== syntax ==="
+for f in "$HOOKS"/*.sh; do
+    if bash -n "$f" 2>/dev/null; then
+        ok "bash -n $(basename "$f")"
+    else
+        bad "bash -n $(basename "$f")" "syntax error"
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# 3. merge-gate.sh behaviour — the gate must allow ordinary merges and block
+#    unreviewed task-branch merges. A parsing failure that blocks everything
+#    (the -P bug) is caught by the "allowed" cases below.
+# ---------------------------------------------------------------------------
+echo
+echo "=== merge-gate.sh ==="
+export CLAUDE_PROJECT_DIR="$TMP/proj"
+mkdir -p "$CLAUDE_PROJECT_DIR/.claude/reviews"
+
+expect_gate() { # <desc> <command> <want_rc> [want_substring]
+    local out rc
+    out=$(printf '{"tool_input":{"command":%s}}' "$(printf '%s' "$2" | jq -Rs .)" \
+        | bash "$HOOKS/merge-gate.sh" 2>&1)
+    rc=$?
+    if printf '%s' "$out" | grep -q 'invalid option'; then
+        bad "$1" "portability error leaked: $out"
+        return
+    fi
+    if [ "$rc" != "$3" ]; then
+        bad "$1" "exit $rc (want $3): $out"
+        return
+    fi
+    if [ -n "${4:-}" ] && ! printf '%s' "$out" | grep -qF "$4"; then
+        bad "$1" "missing '$4' in: $out"
+        return
+    fi
+    ok "$1"
+}
+
+AMP='&&'
+expect_gate "non-merge command allowed"       "echo hello"                             0
+expect_gate "plain branch merge allowed"      "git merge main"                         0
+expect_gate "merge --abort allowed"           "git merge --abort"                      0
+expect_gate "chained non-task merge allowed"  "cd x $AMP git merge origin/feature-1"   0
+expect_gate "unreviewed task merge blocked"   "git merge execute/task-3-slug-abcd"     2 "task 3"
+expect_gate "chained task merge blocked"      "cd x $AMP git merge execute/task-7-a-b" 2 "task 7"
+
+mkdir -p "$CLAUDE_PROJECT_DIR/.claude/reviews/3"
+V="$CLAUDE_PROJECT_DIR/.claude/reviews/3/verdict.json"
+
+echo '{"spec_review":"PASS","code_review":"PASS"}' > "$V"
+expect_gate "reviewed task merge allowed"     "git merge execute/task-3-slug-abcd"     0
+
+echo '{"spec_review":"PASS","code_review":"CONCERNS_ACCEPTED"}' > "$V"
+expect_gate "concerns-accepted allowed"       "git merge execute/task-3-slug-abcd"     0
+
+echo '{"spec_review":"FAIL","code_review":"PASS"}' > "$V"
+expect_gate "spec FAIL blocked"               "git merge execute/task-3-slug-abcd"     2 "Spec review did not pass"
+
+echo '{"spec_review":"PASS","code_review":"FAIL"}' > "$V"
+expect_gate "code FAIL blocked"               "git merge execute/task-3-slug-abcd"     2 "Code review did not pass"
+
+# ---------------------------------------------------------------------------
+# 4. Transcript JSON extraction used by the capture-* hooks.
+# ---------------------------------------------------------------------------
+echo
+echo "=== transcript JSON extraction ==="
+T="$TMP/transcript.jsonl"
+
+extract_ok() { # <desc> <expected-nonempty-result>
+    if [ -n "$2" ]; then ok "$1"; else bad "$1" "extracted nothing"; fi
+}
+
+printf 'noise\n{"task_id":"3","status":"completed"}\nmore\n' > "$T"
+extract_ok "task-completion: single-line" \
+    "$(tail -50 "$T" | grep -oE '\{[^{}]*"status"[^{}]*\}' | tail -1)"
+
+printf 'x\n{"a":1,"tests_still_pass":true}\n' > "$T"
+extract_ok "cynic: single-line" \
+    "$(tail -100 "$T" | grep -oE '\{[^{}]*"tests_still_pass"[^{}]*\}' | tail -1)"
+
+printf 'x\n{\n "simplifications_made": [],\n "tests_still_pass": true\n}\ny\n' > "$T"
+CY=$(tail -200 "$T" | tr '\n' ' ' \
+    | grep -oE '\{[^{}]*"simplifications_made"[^{}]*"tests_still_pass"[^{}]*\}' | tail -1)
+extract_ok "cynic: multiline" "$CY"
+if printf '%s' "$CY" | jq . >/dev/null 2>&1; then
+    ok "cynic: multiline result is valid JSON"
+else
+    bad "cynic: multiline JSON" "not parseable: $CY"
+fi
+
+printf 'x\n{"status" : "PASS","evidence":"ok"}\n' > "$T"
+extract_ok "catastrophiser: spaced colon" \
+    "$(tail -100 "$T" | grep -oE '\{[^{}]*"status"[[:space:]]*:[[:space:]]*"(PASS|FAIL)"[^{}]*\}' | tail -1)"
+
+printf 'x\n{\n "verified_at":"now",\n "status":"FAIL"\n}\n' > "$T"
+extract_ok "catastrophiser: multiline" \
+    "$(tail -200 "$T" | tr '\n' ' ' | grep -oE '\{[^{}]*"verified_at"[^{}]*"status"[^{}]*\}' | tail -1)"
+
+printf 'x\n{"files_updated":["README.md"]}\n' > "$T"
+extract_ok "perfectionist: single-line" \
+    "$(tail -100 "$T" | grep -oE '\{[^{}]*"files_updated"[^{}]*\}' | tail -1)"
+
+printf 'x\n{\n "sections_approved": 3\n}\n' > "$T"
+extract_ok "perfectionist: multiline" \
+    "$(tail -200 "$T" | tr '\n' ' ' | grep -oE '\{[^{}]*"sections_approved"[^{}]*\}' | tail -1)"
+
+# ---------------------------------------------------------------------------
+# 5. create-task-branch.sh prompt parsing.
+# ---------------------------------------------------------------------------
+echo
+echo "=== create-task-branch.sh prompt parsing ==="
+PROMPT='Do the thing.
+TASK_ID: 12 TASK_SLUG: add-auth-middleware
+Go.'
+TID=$(printf '%s\n' "$PROMPT" | sed -nE 's/.*TASK_ID:[[:space:]]*([^[:space:]]+).*/\1/p' | head -1)
+TSLUG=$(printf '%s\n' "$PROMPT" | sed -nE 's/.*TASK_SLUG:[[:space:]]*([^[:space:]]+).*/\1/p' | head -1)
+[ "$TID" = "12" ] && ok "TASK_ID extracted" || bad "TASK_ID" "got '$TID'"
+[ "$TSLUG" = "add-auth-middleware" ] && ok "TASK_SLUG extracted" || bad "TASK_SLUG" "got '$TSLUG'"
+
+NONE=$(printf '%s\n' "no markers here" | sed -nE 's/.*TASK_ID:[[:space:]]*([^[:space:]]+).*/\1/p' | head -1)
+[ -z "$NONE" ] && ok "absent TASK_ID yields empty" || bad "absent TASK_ID" "got '$NONE'"
+
+echo
+echo "================================"
+echo "PASS: $PASS   FAIL: $FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

`grep -P` (PCRE) is a GNU extension. BSD grep — the macOS default — does not have it. Eleven usages across six hooks fail on macOS with `grep: invalid option -- P`.

Same class as #2 and #5 (the `flock` fix in 18fc44c).

## The severe one: `merge-gate.sh` blocks every merge on macOS

`merge-gate.sh` runs as a `PreToolUse` hook on **every** `Bash` call. Its flow:

1. Line 22 detects `git merge` with `grep -qE` — portable, works fine.
2. Line 29 extracts the branch name with `grep -oP '...\K...'` — **fails on BSD grep**.
3. `|| echo ""` silently swallows the failure, leaving `MERGE_BRANCH` empty.
4. Line 31 sees the empty value and exits 2: *"Cannot determine branch being merged. Merge blocked for safety."*

Once step 1 matches there is no path to exit 0, so **all** merges are blocked — including `git merge main` and `git merge --abort`.

Reproduced on macOS 15 (Darwin 24.6.0) against `main`:

```console
$ echo '{"tool_input":{"command":"git merge main"}}' | bash hooks/merge-gate.sh
grep: invalid option -- P
usage: grep [-abcdDEFGHhIiJLlMmnOopqRSsUVvwXxZz] ...
Cannot determine branch being merged. Merge blocked for safety.
$ echo $?
2
```

This is easy to miss when testing by hand: many macOS dev shells have Homebrew `grep` or a `grep` shim earlier in `PATH`, and those *do* support `-P`. The hook runs non-interactively under `#!/bin/bash`, gets no shell functions, and resolves to `/usr/bin/grep`.

The other five hooks fail **open** instead of closed — extraction silently returns nothing, so agent output is never captured and task IDs come back empty. Quieter, but equally broken.

## Changes

All replacements are POSIX and behaviour-preserving:

| Hook | Was | Now |
|---|---|---|
| `merge-gate.sh` (branch) | `-oP` + `\K` | POSIX `awk` `match`/`substr` |
| `merge-gate.sh` (task id) | `-oP` + `\K` | shell parameter expansion |
| `create-task-branch.sh` | `-oP` + `\K` | `sed -nE` capture group |
| `capture-cynic.sh` | `-oP`, `-Pzo (?s)` | `-oE`, `tr '\n' ' '` + `-oE` |
| `capture-catastrophiser.sh` | `-oP`, `-Pzo (?s)` | `-oE`, `tr '\n' ' '` + `-oE` |
| `capture-perfectionist.sh` | `-oP`, `-Pzo (?s)` | `-oE`, `tr '\n' ' '` + `-oE` |
| `task-completion-capture.sh` | `-oP` | `-oE` |

Notes:

- Most `-oP` patterns used **no PCRE features at all** — `-oE` is a drop-in.
- `\s` becomes `[[:space:]]`.
- For the `-Pzo '(?s)...'` cases, flattening newlines to spaces first gives the same DOTALL reach without `-P` or `-z`, and drops the now-unneeded `tr '\0' '\n'`.
- The gate's security property is preserved: unreviewed task-branch merges are still blocked, and `PASS`/`CONCERNS_ACCEPTED`/`FAIL` handling is unchanged.

## Tests

Adds `tests/test-hook-portability.sh` plus a CI matrix over `ubuntu-latest` (GNU) and `macos-latest` (BSD). Covers the gate's allow **and** block paths, the transcript extractors including the multiline ones, `bash -n` on every hook, and a static scan that fails if `grep -P` reappears.

49/49 green locally on macOS (BSD grep 2.6.0-FreeBSD); the ubuntu leg in CI covers GNU.

An end-to-end check with a real repo: before this change `git merge feature` was blocked with exit 2; after it, the merge completes and an unreviewed `execute/task-9-demo-ab12` branch is still correctly blocked with *"No review verdict found for task 9"*.

## Note on #9

Two interactions worth flagging:

- #9 **deletes** the two `grep -oP` lines in `create-task-branch.sh` (it switches to reading `current_task` from state). If #9 lands first, that hunk here becomes redundant and can be dropped — the rest is independent.
- #9 **introduces a new** `grep -oP` in `git-branch-guard.sh`, which would reintroduce this bug in another `PreToolUse` Bash hook. It has a `sed` fallback, so it degrades rather than hard-fails, but on macOS the PCRE branch never matches — so it silently falls back to the exact greedy `sed` the change was meant to fix, and leaks `grep: invalid option -- P` to stderr on every Bash call. A portable form of that same extraction:

  ```bash
  GIT_SUBCOMMAND=$(printf '%s\n' "$COMMAND" | awk '{
      if (match($0, /(^|[|;&[:space:]])git([[:space:]]+-[a-zA-Z-]+(=[^[:space:]]+)?([[:space:]]+[^[:space:]]+)?)*[[:space:]]+[a-z][a-z0-9-]*/)) {
          s = substr($0, RSTART, RLENGTH)
          sub(/.*[[:space:]]/, "", s)
          print s
      }
  }')
  ```

  The CI matrix added here would catch it either way.

Happy to rebase, split the CI addition out, or adjust anything.